### PR TITLE
wheel 0.38.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,3 +58,6 @@ extra:
     - pelson
     - ocefpaf
     - mingwandroid
+  skip-lints:
+    - uses_setup_py
+    - missing_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.37.1" %}
+{% set version = "0.38.4" %}
 
 package:
   name: wheel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wheel/wheel-{{ version }}.tar.gz
-  sha256: e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
+  sha256: 965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
+{% set name = "wheel" %}
 {% set version = "0.38.4" %}
 
 package:
-  name: wheel
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/w/wheel/wheel-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<37]
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - wheel = wheel.cli:main
@@ -18,7 +19,8 @@ build:
 requirements:
   host:
     - python
-    - setuptools >=40.9.0
+    - setuptools
+    # pip has not to be present in the host section
   run:
     - python
 
@@ -26,11 +28,14 @@ test:
   imports:
     - wheel
     - wheel.cli
+    - wheel.vendored
+    - wheel.vendored.packaging
   requires:
     - pip
   commands:
     - pip check
     - wheel --help
+    - wheel version
 
 about:
   home: https://github.com/pypa/wheel
@@ -38,8 +43,14 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: A built-package format for Python.
+  description: |
+    This library is the reference implementation of the Python wheel packaging standard, 
+    as defined in PEP 427.
+    It has two different roles:
+      1. A setuptools extension for building wheels that provides the bdist_wheel setuptools command
+      2. A command line tool for working with wheel files
   dev_url: https://github.com/pypa/wheel
-  doc_url: https://github.com/pypa/wheel/blob/master/README.rst
+  doc_url: https://wheel.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Jira ticket:** [PKG-1044](https://anaconda.atlassian.net/browse/PKG-1044) (wheel-0.38.4)

**The upstream data:**
Changelog: https://github.com/pypa/wheel/blob/main/docs/news.rst
* There are no broken changes, only dropping Python 3.6 support
* [Diff between the latest and previous upstream releases](https://github.com/pypa/wheel/compare/0.37.1...0.38.4)

Requirements:
 * setup.cfg:  https://github.com/pypa/wheel/blob/0.38.4/setup.cfg
 * setup.py:  https://github.com/pypa/wheel/blob/0.38.4/setup.py

**_Actions:_**

1. Add jinja2 templates
2. Remove `setuptools` pinning
3. Add a comment about `pip` in `host`
4. Add new `test/imports`
5. Add new `test/commands`

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.38.4
 * Release on PyPi:
    * version: 0.38.4
    * date: 2022-11-09T20:43:51
* [PyPi history](https://pypi.org/project/wheel/#history)
 * Popularity: 
    * 3 months downloads: 14208420.0
    * All time:  54568210 downloads -  wheel  0.38.4  A built-package format for Python.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/pypa/wheel/tree/0.38.4 exists
6. - [x] Check the pinnings    
11. - [x] Verify that the `build_number` is correct
12. - [x] has `setuptools`
13. - [x] the package DOESN'T need `wheel`
14. - [x] `pip` in test
15. - [x] Verify the test section
16. - [x] Verify if the package is `architecture specific`
17. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
18.  - [x] license_file: LICENSE.txt is present
19. - [x] license_family MIT is present
20. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/wheel-feedstock/recipe/meta.yaml
Dependencies: ['python', 'setuptools >=40.9.0']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/wheel-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/wheel-feedstock/tree/0.38.4)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/wheel)
* [Diff between upstream and feature branch](https://github.com/conda-forge/wheel-feedstock/compare/main...AnacondaRecipes:0.38.4)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/wheel-feedstock/compare/master...AnacondaRecipes:0.38.4)
* [The last merged PRs](https://github.com/AnacondaRecipes/wheel-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.38.4 git@github.com:AnacondaRecipes/wheel-feedstock.git
```
