### PR TITLE
v0.46.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wheel" %}
-{% set version = "0.45.1" %}
+{% set version = "0.46.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,28 +7,27 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729
+  sha256: e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   entry_points:
-    - wheel = wheel.cli:main
+    - wheel = wheel._commands:main
 
 requirements:
   host:
     - python
-    - flit-core >=3.8,<4
     - python-installer
+    - flit-core >=3.11,<4
   run:
     - python
+    - packaging >=24.0
 
 test:
   imports:
     - wheel
-    - wheel.cli
-    - wheel.vendored
-    - wheel.vendored.packaging
+    - wheel._commands
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,5 +56,3 @@ extra:
     - pelson
     - ocefpaf
     - mingwandroid
-  skip-lints:
-    - missing_wheel


### PR DESCRIPTION
wheel v0.46.3

**Destination channel:**  defaults

### Links

- [PKG-12212](https://anaconda.atlassian.net/browse/PKG-12212) 
- [Upstream repository](https://github.com/pypa/wheel/tree/0.46.3)
- [Upstream changelog/diff](https://github.com/pypa/wheel/compare/0.45.1...0.46.3)
    - Including: https://github.com/pypa/wheel/commit/a99cdd578f4ae3c058a6297ab38b4b14c476e082


### Explanation of changes:

- Bump version and SHA
- Adds packaging as run dependency as it's been un-vendored
- Update imports to match the refactored upstream. 


[PKG-12212]: https://anaconda.atlassian.net/browse/PKG-12212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ